### PR TITLE
Query hosts using go template syntax

### DIFF
--- a/arsenic/cmd/hosts.go
+++ b/arsenic/cmd/hosts.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
+	"text/template"
 
 	"github.com/defektive/arsenic/arsenic/lib/host"
 	"github.com/defektive/arsenic/arsenic/lib/set"
@@ -23,9 +25,38 @@ var hostsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		hostsArgs, _ := cmd.Flags().GetStringSlice("host")
 
+		query, _ := cmd.Flags().GetString("query")
+
 		var hosts []host.Host
 		if len(hostsArgs) > 0 {
 			hosts = host.Get(hostsArgs)
+		} else if query != "" {
+			hostTemplate := template.New("host")
+			funcMap := make(template.FuncMap)
+			funcMap["in"] = func(s1 []string, s2 ...string) bool {
+				// Loop through s1 then s2 and check whether any values of s2 are equal to any values in s1
+				return slice.Any(s1, func(s1Item interface{}) bool {
+					return slice.Any(s2, func(s2Item interface{}) bool {
+						return s1Item == s2Item
+					})
+				})
+			}
+
+			funcMap["appendMatch"] = func(match host.Host) string {
+				hosts = append(hosts, match)
+				return ""
+			}
+
+			templateString := fmt.Sprintf(`{{range $host := .}}{{with .Metadata}}{{if %s}}{{appendMatch $host}}{{end}}{{end}}{{end}}`, query)
+			_, err := hostTemplate.Funcs(funcMap).Parse(templateString)
+			if err != nil {
+				panic(err)
+			}
+			err = hostTemplate.Execute(os.Stdout, host.All())
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
 		} else {
 			hosts = host.All()
 		}
@@ -38,7 +69,7 @@ var hostsCmd = &cobra.Command{
 		shouldSave := len(userFlagsToRemove) > 0 || len(userFlagsToAdd) > 0 || updateArsenicFlags
 
 		for _, host := range hosts {
-			if  shouldSave {
+			if shouldSave {
 				flagsSet := set.NewSet(reflect.TypeOf(""))
 				for _, flag := range host.Metadata.UserFlags {
 					if slice.Any(userFlagsToRemove, func(item interface{}) bool { return flag == item }) {
@@ -80,4 +111,5 @@ func init() {
 	hostsCmd.RegisterFlagCompletionFunc("host", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return host.AllDirNames(), cobra.ShellCompDirectiveDefault
 	})
+	hostsCmd.Flags().StringP("query", "q", "", "the host query")
 }

--- a/arsenic/cmd/hosts.go
+++ b/arsenic/cmd/hosts.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/defektive/arsenic/arsenic/lib/host"
 	"github.com/defektive/arsenic/arsenic/lib/set"
 	"github.com/defektive/arsenic/arsenic/lib/slice"
+	"github.com/defektive/arsenic/arsenic/lib/util"
 	"github.com/ryanuber/columnize"
 	"github.com/spf13/cobra"
 )
@@ -50,11 +50,13 @@ var hostsCmd = &cobra.Command{
 			templateString := fmt.Sprintf(`{{range $host := .}}{{with .Metadata}}{{if %s}}{{appendMatch $host}}{{end}}{{end}}{{end}}`, query)
 			_, err := hostTemplate.Funcs(funcMap).Parse(templateString)
 			if err != nil {
-				panic(err)
+				cmd.PrintErrln(err)
+				return
 			}
-			err = hostTemplate.Execute(os.Stdout, host.All())
+
+			err = hostTemplate.Execute(util.NoopWriter{}, host.All())
 			if err != nil {
-				fmt.Println(err)
+				cmd.PrintErrln(err)
 				return
 			}
 		} else {

--- a/arsenic/lib/host/host.go
+++ b/arsenic/lib/host/host.go
@@ -32,7 +32,7 @@ type Metadata struct {
 
 type Host struct {
 	dir      string
-	Metadata Metadata
+	Metadata *Metadata
 }
 
 func InitHost(dir string) Host {
@@ -90,7 +90,7 @@ func InitHost(dir string) Host {
 	metadata.UDPPorts = host.udpPorts()
 	metadata.Flags = flags
 
-	host.Metadata = metadata
+	host.Metadata = &metadata
 	return host
 }
 

--- a/arsenic/lib/util/util.go
+++ b/arsenic/lib/util/util.go
@@ -151,3 +151,10 @@ func fileExists(filename string) bool {
 	}
 	return !info.IsDir()
 }
+
+type NoopWriter struct {
+}
+
+func (w NoopWriter) Write(bytes []byte) (int, error) {
+	return 0, nil
+}


### PR DESCRIPTION
We can add new functions to the template by adding them to the funcMap. Figured to make this a draft pull request since not all of the functions that we want are implemented but it currently works.

`arsenic hosts -q 'in .UserFlags "my_flag"' -a "Added_to_queried_hosts"`