### PR TITLE
Fixed generation of the scope-ips-generated-client-domains.txt file

### DIFF
--- a/scripts/discover/as-ip-recon
+++ b/scripts/discover/as-ip-recon
@@ -24,7 +24,6 @@ PRIVATE_IP_REGEX="(127\.[0-9]{1,3}\.|10\.[0-9]{1,3}\.|192\.168\.|172\.(1[6-9]|2[
 # create scope ips from domains
 grep -riP "has (IPv6 )?address" recon/domains/  \
   | awk '{print $NF}' \
-  | removeInvalidDomains \
   | tee scope-ips-generated-client-domains.txt
 
 

--- a/scripts/discover/as-ip-recon
+++ b/scripts/discover/as-ip-recon
@@ -24,6 +24,7 @@ PRIVATE_IP_REGEX="(127\.[0-9]{1,3}\.|10\.[0-9]{1,3}\.|192\.168\.|172\.(1[6-9]|2[
 # create scope ips from domains
 grep -riP "has (IPv6 )?address" recon/domains/  \
   | awk '{print $NF}' \
+  | sort -d | uniq \
   | tee scope-ips-generated-client-domains.txt
 
 


### PR DESCRIPTION
The removeInvalidDomains greps out IP addresses so I removed the call to it in as-ip-recon