### PR TITLE
as-buster changes

### DIFF
--- a/bin/as-buster
+++ b/bin/as-buster
@@ -76,7 +76,7 @@ run(){
     # Get hostname from URL
     # Remove URL scheme (http:// or https://) and remove port (:port)
     hostname=$(echo "$url" | sed 's|http\(s\)\?://||;s/:[0-9]\+//' | awk -F '/' '{print $1}')
-    output_file="gobuster.$(echo "$url" | sed 's|://|.|;s|/$||;s|/|.|g').$wordlist_name.txt"
+    output_file="gobuster.$method.$(echo "$url" | sed 's|://|.|;s|/$||;s|/|.|g').$wordlist_name.txt"
     output_path="$output_dir/$output_file"
 
     # if host dir exists we are in the op root.
@@ -95,10 +95,6 @@ run(){
     fi
 
     if [[ -n "$hostname" ]]; then
-        if [ ! -f hostname ]; then
-            echo "$hostname" > hostname
-        fi
-
         # Check if hostname is an IP
         if ! echo $hostname | grep -qP "(?:(?:2(?:[0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9])\.){3}(?:(?:2([0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9]))"; then
           echo "$hostname" >> recon/hostnames.txt
@@ -143,6 +139,7 @@ if [[ $# -eq 0 ]]; then
     exit 0
 fi
 
+method="GET"
 output_dir="recon"
 status_codes="404"
 while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
@@ -155,6 +152,11 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
             ;;
         -x|--extensions)
             add_gb_args $1 "$2"
+            shift
+            ;;
+        -m|--method)
+            method=$(echo "$2" | tr 'a-z' 'A-Z')
+            add_gb_args $1 "$method"
             shift
             ;;
         -k|--no-tls-validation)

--- a/bin/as-buster
+++ b/bin/as-buster
@@ -15,8 +15,8 @@
 ##|  -h, --help                             Help for arbuster
 ##|  -m, --method                           Use the following HTTP method (default "GET")
 ##|  -k, --no-tls-validation                Skip SSL certificate verification
-##|  -o, --output-dir string                Host specific output directory to write results to
-##|                                         Default: recon
+##|  -o, --output string                    Name of the file to write the results to
+##|                                         Default: gobuster.{HTTP_METHOD}.{URL}.{WORDLIST}.txt
 ##|  --proxy string                         Proxy to use for requests [[http(s)|socks(4|5)]://host:port]
 ##|  -b, --status-codes-blacklist string    Comma delimited list of blacklisted status codes
 ##|                                         Format: [+|-]code[,code]
@@ -76,7 +76,9 @@ run(){
     # Get hostname from URL
     # Remove URL scheme (http:// or https://) and remove port (:port)
     hostname=$(echo "$url" | sed 's|http\(s\)\?://||;s/:[0-9]\+//' | awk -F '/' '{print $1}')
-    output_file="gobuster.$method.$(echo "$url" | sed 's|://|.|;s|/$||;s|/|.|g').$wordlist_name.txt"
+    if [[ -z "$output_file" ]]; then
+        output_file="gobuster.$method.$(echo "$url" | sed 's|://|.|;s|/$||;s|/|.|g').$wordlist_name.txt"
+    fi
     output_path="$output_dir/$output_file"
 
     # if host dir exists we are in the op root.
@@ -139,6 +141,7 @@ if [[ $# -eq 0 ]]; then
     exit 0
 fi
 
+output_file=""
 method="GET"
 output_dir="recon"
 status_codes="404"
@@ -222,8 +225,8 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
             add_gb_args --exclude-length "$2"
             shift
             ;;
-        -o|--output-dir)
-            output_dir="$2"
+        -o|--output)
+            output_file="$2"
             shift
             ;;
         -h|--help)

--- a/scripts/init/as-init-op
+++ b/scripts/init/as-init-op
@@ -23,7 +23,7 @@ OP_NAME=$(basename $(pwd))
 _ "Creating op: $OP_NAME"
 
 mkdir -p apps bin report/{findings,sections,static,social} hosts recon/domains
-touch {apps,bin,recon}/.keep report/static/.keep
+touch {apps,bin,recon,hosts}/.keep report/static/.keep
 
 if [ -f "/usr/share/nmap/nmap.xsl" ]; then
   cp /usr/share/nmap/nmap.xsl report/static

--- a/scripts/recon/as-content-discovery
+++ b/scripts/recon/as-content-discovery
@@ -43,56 +43,25 @@ set -eu
 WEB_PORTS="(80|443|3000|8000|8001|8080|8443)"
 WEB_PORT_REGEX="portid=\"$WEB_PORTS\"|tcp/$WEB_PORTS"
 
+function genOutputFileName {
+  echo "gobuster.$(echo "$1" | sed "s/:\/\//./" | sed 's/\//\./g').$wordlist_name.txt"
+}
+
 function newGetHostUrls {
-  for host in hosts/*; do
-    if compgen -G "$host/recon/*hostnames.txt" > /dev/null 2>&1; then
-      cat $host/recon/*hostnames.txt
-    elif compgen -G "$host/recon/*ip-addresses.txt" > /dev/null 2>&1; then
-      cat $host/recon/*ip-addresses.txt
-    fi
-  done | sort -u \
-  | as-prune-blacklisted-domains \
-  | grep -vP "(//((sso\.|scm\.)?azurewebsites\.net|(sso\.|scm\.)?azure\-mobile\.net|s3\.amazonaws\.com)$)|((\.secureserver\.net|\.microsoftonline\.com|windows\.net|amazonaws\.com|hscoscdn)$)"  \
-  | while read hostname; do
+  arsenic hosts -p http  | while read url; do
 
-    host=$(grep -rP "^$(echo $hostname | sed 's/\./\\./g')$" hosts/*/recon/*{hostnames,ip-addresses}.txt 2>/dev/null | head -n1 | cut -d/ -f2)
-
-    if [ -z "$host" ]; then
-      _warn "no host found for hostname: $hostname"
-    fi
+    hostname=$(echo "$url" | sed 's|https\?://||g' | awk -F ':' '{print $1}')
+    hostPath=$(arsenic hosts -H "$hostname" --paths)
+    host=$(echo "$hostPath" | awk -F '/' '{print $2}')
 
     draft="nope"
-    if [ -f "hosts/$host/00_metadata.md" ] ; then
-      draft=$(grep draft "hosts/$host/00_metadata.md" || echo "nope")
+    if [ -f "$hostPath/00_metadata.md" ] ; then
+      draft=$(grep draft "$hostPath/00_metadata.md" || echo "nope")
     fi
     if [ "$draft" == "nope" ]; then
-
-      if grep -P "$WEB_PORT_REGEX" hosts/$host/recon/nmap-* > /dev/null 2>&1; then
-        grep -P "$WEB_PORT_REGEX" hosts/$host/recon/nmap-* | grep -hoP "$WEB_PORTS" | sort -d | uniq | while read port; do
-          SHOULD_ECHO=1
-          proto="http://"
-          if echo $port | grep 443 > /dev/null 2>&1; then
-             proto="https://"
-          fi
-          if [ "$port" == "80" ] || [ "$port" == "443" ] ; then
-            url="${proto}${hostname}"
-            if [ "$port" == "80" ] ; then
-              if grep -P "\b443\b" hosts/$host/recon/nmap-* >/dev/null 2>&1 ; then
-                # this is port 80, but 443 is listening. lets use that instead
-                SHOULD_ECHO=0
-              fi
-            fi
-          else
-            url="${proto}${hostname}:$port"
-          fi
-
-          if [ $SHOULD_ECHO -eq 1 ]; then
-            output_file="gobuster.$(echo "$url" | sed "s/:\/\//./" | sed 's/\//\./g').$wordlist_name.txt"
-            if [ ! -f "hosts/$host/recon/$output_file" ] ; then
-              echo $host $url
-            fi
-          fi
-        done
+      output_file=$(genOutputFileName "$url")
+      if [ ! -f "$hostPath/recon/$output_file" ] ; then
+        echo $host $url
       fi
     fi
   done | sort -d | uniq
@@ -114,7 +83,7 @@ function scanHost {
   if [ "$draft" == "nope" ]; then
     _info "Content Discovery / $host / $url / preparing"
     cd "hosts/$host"
-    output_file="gobuster.$(echo "$url" | sed "s/:\/\//./" | sed 's/\//\./g').$wordlist_name.txt"
+    output_file=$(genOutputFileName "$url")
 
     gitPull
     if [ ! -f "recon/$output_file" ] ; then

--- a/scripts/recon/as-content-discovery
+++ b/scripts/recon/as-content-discovery
@@ -114,7 +114,7 @@ function scanHost {
   if [ "$draft" == "nope" ]; then
     _info "Content Discovery / $host / $url / preparing"
     cd "hosts/$host"
-    output_file="gobuster.$(echo "$url" | sed "s/:\/\//./" | sed 's/\//\./g').$wordlist_name.txt"
+    output_file="gobuster.GET.$(echo "$url" | sed "s/:\/\//./" | sed 's/\//\./g').$wordlist_name.txt"
 
     gitPull
     if [ ! -f "recon/$output_file" ] ; then

--- a/scripts/recon/as-content-discovery
+++ b/scripts/recon/as-content-discovery
@@ -114,7 +114,7 @@ function scanHost {
   if [ "$draft" == "nope" ]; then
     _info "Content Discovery / $host / $url / preparing"
     cd "hosts/$host"
-    output_file="gobuster.GET.$(echo "$url" | sed "s/:\/\//./" | sed 's/\//\./g').$wordlist_name.txt"
+    output_file="gobuster.$(echo "$url" | sed "s/:\/\//./" | sed 's/\//\./g').$wordlist_name.txt"
 
     gitPull
     if [ ! -f "recon/$output_file" ] ; then
@@ -136,7 +136,7 @@ function scanHost {
           set +e
 
           _info "Content Discovery / $host / $url / running"
-          as-buster -k -e -a Firefox -u $url -w $wordlist_file
+          as-buster -k -e -a Firefox -u $url -w $wordlist_file -o "$output_file"
         fi
 
         gitCommit "." "Gobuster complete: $url"

--- a/scripts/recon/as-content-discovery
+++ b/scripts/recon/as-content-discovery
@@ -40,8 +40,6 @@ fi
 #set -euo pipefail
 set -eu
 # set -x
-WEB_PORTS="(80|443|3000|8000|8001|8080|8443)"
-WEB_PORT_REGEX="portid=\"$WEB_PORTS\"|tcp/$WEB_PORTS"
 
 function genOutputFileName {
   echo "gobuster.$(echo "$1" | sed "s/:\/\//./" | sed 's/\//\./g').$wordlist_name.txt"


### PR DESCRIPTION
- Incorporate the request used in the gobuster output file
- Removed the hostname file being created for each host
- You can now specify the output file name for as-buster (this is so that if the naming convention of the output file changes in as-buster, we don't need to change as-content-discovery)
- `arsenic hosts -p http` is now being used