### PR TITLE
DNS discovery improvements

### DIFF
--- a/bin/as-crtsh-slurp
+++ b/bin/as-crtsh-slurp
@@ -1,0 +1,24 @@
+#! /bin/bash
+DOMAIN=$1
+
+curl -s 'https://crt.sh/?q=%25.'$DOMAIN \
+	-H 'authority: crt.sh' \
+	-H 'cache-control: max-age=0' \
+	-H 'dnt: 1' \
+	-H 'upgrade-insecure-requests: 1' \
+	-H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36' \
+	-H 'sec-fetch-user: ?1' \
+	-H 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9' \
+	-H 'sec-fetch-site: same-origin' \
+	-H 'sec-fetch-mode: navigate' \
+	-H 'referer: https://crt.sh/' \
+	-H 'accept-encoding: gzip, deflate, br' \
+	-H 'accept-language: en-US,en;q=0.9' \
+  --compressed \
+	| grep "$DOMAIN" \
+	| grep "TD" \
+	| grep -v "outer"\
+	| sed 's/\s*<\/\?TD>//g' \
+	| sed 's/<BR>/\n/g' \
+	| sed 's/^\*\.//g' \
+	| sort -u

--- a/scripts/discover/as-combine-subdomains
+++ b/scripts/discover/as-combine-subdomains
@@ -20,22 +20,22 @@ mkdir -p recon/domains recon/discover recon/ips
 
 function root_domain_recon {
   domain=$(echo $1 | tr 'A-Z' 'a-z')
-  if ! echo "$domain" | as-prune-blacklisted-domains | grep "$domain" > /dev/null ; then
-    _warn "Skipping common domain: $domain"
-  else
-    mkdir -p "recon/domains/$domain"
+  mkdir -p "recon/domains/$domain"
+  # always right in scope subdomains to a txt file
+  grep -P "$(echo "$domain" |  sed 's/\([\.\-]\)/\\\1/g' )\$" scope-domains.txt > "recon/domains/$domain/subdomains-scope.txt"
 
-    {
-      if compgen -G "recon/domains/$domain/subdomains-*.txt" > /dev/null 2>&1; then
-        _ "Combining discovered subdomains"
-        cat "recon/domains/$domain/"subdomains-*.txt 2>/dev/null
-      fi
-    } \
-    | sort -d \
-    | uniq \
-    | ensureDomainInScope \
-    | tee "recon/domains/$domain/subdomains.txt"
-  fi
+  # we do not need to skip out of scope root domains here, since we are combining what was generated
+  # whatever is generating the subdomains-*.txt files will need to ensure they only add in scope domains.
+  {
+    if compgen -G "recon/domains/$domain/subdomains-*.txt" > /dev/null 2>&1; then
+      _ "Combining discovered subdomains"
+      cat "recon/domains/$domain/"subdomains-*.txt 2>/dev/null
+    fi
+  } \
+  | sort -d \
+  | uniq \
+  | ensureDomainInScope \
+  | tee "recon/domains/$domain/subdomains.txt"
 }
 
 # Recon root domains

--- a/scripts/discover/as-subdomain-discovery
+++ b/scripts/discover/as-subdomain-discovery
@@ -24,7 +24,6 @@ function root_domain_recon {
     _warn "Skipping common domain: $domain"
   else
     mkdir -p "recon/domains/$domain"
-
     RECON_FILE="recon/domains/$domain/amass-enum-active.txt"
     if [ ! -f "$RECON_FILE" ] ; then
       _ "amass enum active $domain"
@@ -40,6 +39,17 @@ function root_domain_recon {
       | tee "$RECON_FILE"
     fi
 
+    RECON_FILE="recon/domains/$domain/crtsh.txt"
+    if [ ! -f "$RECON_FILE" ] ; then
+      _ "crtsh $domain"
+      as-crtsh-slurp "$domain" \
+      | tee "$RECON_FILE"
+    fi
+
+    cat "$RECON_FILE" \
+      | ensureDomainInScope \
+      | uniq > "recon/domains/$domain/subdomains-crtsh.txt"
+
     {
       if [ -f "recon/domains/$domain/amass-enum-active.txt" ]; then
         cat "recon/domains/$domain/amass-enum-active.txt" 2>/dev/null | awk '{print $2}'
@@ -51,6 +61,7 @@ function root_domain_recon {
     } \
     | grep -P "$(echo "$domain" | sed 's/\./\\./g')\$" \
     | sort -d \
+    | ensureDomainInScope \
     | uniq > "recon/domains/$domain/subdomains-amass.txt"
   fi
 }


### PR DESCRIPTION
Add crtsh back, I guess amass doesnt get everything :shrug:
Ensure domains added to subdomains-*.txt are in scope
Add domains from scope-domains.txt to the recon/domains
subdomains-scope.txt

Testing:

- Add some domains to your scope
- run `arsenic discover`
- it should run successfully
- only inscope domains should be in recon/domains/subdomains-*.txt
- only inscope domains should be in scope-domains-generated-*.txt